### PR TITLE
Add self-healing Flask helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,21 @@
 from flask import Flask, request, jsonify
+
 app = Flask(__name__)
 
-@app.route('/status')
-def status(): return 'OK', 200
 
-@app.route('/run-task', methods=['POST'])
+@app.route("/status")
+def status():
+    return "OK", 200
+
+
+@app.route("/run-task", methods=["POST"])
 def run():
     import subprocess, json
-    cmd = request.get_json().get('command', '')
-    out = subprocess.getoutput(cmd)
-    return jsonify({'output': out})
 
-if __name__ == '__main__': app.run(port=5001)
+    cmd = request.get_json().get("command", "")
+    out = subprocess.getoutput(cmd)
+    return jsonify({"output": out})
+
+
+if __name__ == "__main__":
+    app.run(port=5001)

--- a/run_localGPT_API.py
+++ b/run_localGPT_API.py
@@ -84,6 +84,11 @@ QA = RetrievalQA.from_chain_type(
 app = Flask(__name__)
 
 
+@app.route("/status")
+def status():
+    return jsonify({"status": "online"})
+
+
 @app.route("/api/delete_source", methods=["GET"])
 def delete_source_route():
     folder_name = "SOURCE_DOCUMENTS"
@@ -166,7 +171,7 @@ def prompt_route():
     if user_prompt:
         # Acquire the lock before processing the prompt
         with request_lock:
-            # print(f'User Prompt: {user_prompt}')              
+            # print(f'User Prompt: {user_prompt}')
             # Get the answer from the chain
             res = QA(user_prompt)
             answer, docs = res["result"], res["source_documents"]

--- a/run_task.py
+++ b/run_task.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Simple helper to send commands to the local Flask agent."""
+import argparse
+import requests
+from utils.ensure_agent_alive import ensure_agent_alive
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run command via local agent")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to execute")
+    args = parser.parse_args()
+
+    cmd = " ".join(args.command).strip()
+    if not cmd:
+        parser.error("command required")
+
+    if ensure_agent_alive():
+        resp = requests.post(
+            "http://localhost:5001/run-task",
+            json={"command": cmd},
+            timeout=30,
+        )
+        try:
+            print(resp.json())
+        except Exception:
+            print(resp.text)
+    else:
+        print("❌ Agent failed to restart — check logs.")
+
+
+if __name__ == "__main__":
+    main()

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Start the simple Flask server for local-agent
+cd "$(dirname "$0")"
+if [ -d "venv" ]; then
+    source venv/bin/activate
+fi
+mkdir -p logs
+echo "[START] Starting Flask server at $(date)" >> logs/flask_recovery.log
+nohup python3 app.py >> logs/flask.log 2>&1 &

--- a/utils/ensure_agent_alive.py
+++ b/utils/ensure_agent_alive.py
@@ -1,0 +1,33 @@
+import subprocess
+import time
+from typing import Optional
+
+import requests
+
+
+def ensure_agent_alive(url: str = "http://localhost:5001/status") -> bool:
+    """Ensure the local Flask agent is running.
+
+    Sends a GET request to ``url``. If the request fails or returns a non-200
+    status, ``start_flask.sh`` is executed to (re)start the server.
+
+    After a short pause the status endpoint is queried again.
+    Returns ``True`` if the server responds with HTTP 200, ``False`` otherwise.
+    """
+
+    try:
+        r = requests.get(url, timeout=2)
+        if r.status_code == 200:
+            return True
+    except Exception:
+        pass
+
+    # Attempt restart
+    subprocess.run(["bash", "start_flask.sh"])  # best effort
+    time.sleep(3)
+
+    try:
+        r = requests.get(url, timeout=3)
+        return r.status_code == 200
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- add shell script to start Flask server
- ensure the agent is running before making API calls
- add simple command runner that uses the helper
- expose `/status` in the full API server
- format files with `black`

## Testing
- `bash start_flask.sh` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686280fecda4833095a9720864c75e55