### PR TITLE
Add Flask agent tests and startup utilities

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,29 +2,29 @@ name: Test Flask Operator
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.10
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
 
-    - name: Install dependencies
-      run: pip install flask
+      - name: Install dependencies
+        run: pip install flask requests pytest
 
-    - name: Start Flask app
-      run: |
-        python3 app.py &
-        sleep 3
+      - name: Start Flask app
+        run: |
+          ./start_flask.sh
+          sleep 3
 
-    - name: Test /status
-      run: curl -f http://localhost:5001/status
+      - name: Run tests
+        run: pytest -v

--- a/agent_manager.py
+++ b/agent_manager.py
@@ -1,0 +1,44 @@
+import os
+import signal
+import subprocess
+import time
+
+import requests
+
+AGENT_URL = "http://localhost:5001/status"
+SCRIPT = "./start_flask.sh"
+PID_FILE = "flask.pid"
+
+
+def ensure_agent_alive(timeout: float = 0.5, attempts: int = 20) -> bool:
+    """Ensure the Flask agent is running."""
+    try:
+        r = requests.get(AGENT_URL, timeout=timeout)
+        if r.ok:
+            return True
+    except Exception:
+        pass
+
+    subprocess.run(["sh", SCRIPT], check=False)
+
+    for _ in range(attempts):
+        time.sleep(timeout)
+        try:
+            r = requests.get(AGENT_URL, timeout=timeout)
+            if r.ok:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def stop_agent() -> int | None:
+    if os.path.exists(PID_FILE):
+        try:
+            pid = int(open(PID_FILE).read().strip())
+            os.kill(pid, signal.SIGTERM)
+            os.remove(PID_FILE)
+            return pid
+        except Exception:
+            return None
+    return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ Streamlit-extras
 openpyxl
 playwright
 Pillow
+pytest

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+python app.py > flask.log 2>&1 &
+echo $! > flask.pid

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import time
+
+import requests
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from agent_manager import ensure_agent_alive, stop_agent  # noqa: E402
+
+BASE_URL = "http://localhost:5001"
+
+
+def wait_for_server():
+    for _ in range(20):
+        try:
+            r = requests.get(f"{BASE_URL}/status", timeout=0.5)
+            if r.status_code == 200:
+                return
+        except Exception:
+            time.sleep(0.5)
+    raise RuntimeError("Server did not start")
+
+
+def start_agent():
+    os.system("sh start_flask.sh")
+    wait_for_server()
+
+
+def teardown_module(module):
+    stop_agent()
+
+
+def test_status_and_run_task():
+    start_agent()
+    resp = requests.get(f"{BASE_URL}/status")
+    assert resp.status_code == 200
+    assert resp.text == "OK"
+
+    resp = requests.post(f"{BASE_URL}/run-task", json={"command": "echo test"})
+    assert resp.status_code == 200
+    assert resp.json()["output"].strip() == "test"
+    stop_agent()
+
+
+def test_ensure_agent_alive_starts_agent():
+    start_agent()
+    stop_agent()
+    assert ensure_agent_alive() is True
+    resp = requests.get(f"{BASE_URL}/status")
+    assert resp.status_code == 200
+    stop_agent()


### PR DESCRIPTION
## Summary
- add agent_manager helper with `ensure_agent_alive`
- create `start_flask.sh` helper script
- write tests for Flask app endpoints and auto-restart behaviour
- install pytest in requirements
- run the tests in CI
- quote the Python version in the workflow to avoid YAML parsing issues
- fix lint issues in new files

## Testing
- `pre-commit run --files .github/workflows/test.yml agent_manager.py start_flask.sh tests/test_agent.py requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862af85d4a483309ef66862471e3e96