### PR TITLE
Add agent tests and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,29 +2,28 @@ name: Test Flask Operator
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.10
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
 
-    - name: Install dependencies
-      run: pip install flask
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
 
-    - name: Start Flask app
-      run: |
-        python3 app.py &
-        sleep 3
-
-    - name: Test /status
-      run: curl -f http://localhost:5001/status
+      - name: Start Flask app
+        run: |
+          bash start_flask.sh
+          sleep 3
+      - name: Run tests
+        run: pytest -vv

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,7 @@ cython_debug/
 #MacOS
 .DS_Store
 SOURCE_DOCUMENTS/.DS_Storerun_task.log
+
+# Local agent test files
+flask.pid
+flask.log

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+flask
+requests
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ Streamlit-extras
 openpyxl
 playwright
 Pillow
+pytest

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+python3 app.py > flask.log 2>&1 &
+echo $! > flask.pid

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,71 @@
+import os
+import signal
+import subprocess
+import time
+
+import pytest
+import requests
+
+BASE_URL = "http://localhost:5001"
+
+
+def ensure_agent_alive():
+    """Start the Flask agent if it is not already running."""
+    try:
+        requests.get(f"{BASE_URL}/status", timeout=1)
+        return False
+    except Exception:
+        subprocess.Popen(["bash", "start_flask.sh"])
+        for _ in range(10):
+            try:
+                requests.get(f"{BASE_URL}/status", timeout=1)
+                return True
+            except Exception:
+                time.sleep(1)
+        raise RuntimeError("Agent failed to start")
+
+
+def stop_agent():
+    if os.path.exists("flask.pid"):
+        with open("flask.pid") as f:
+            pid = int(f.read().strip())
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        os.remove("flask.pid")
+        time.sleep(1)
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    stop_agent()
+
+
+def test_status_and_run_task():
+    ensure_agent_alive()
+    resp = requests.get(f"{BASE_URL}/status")
+    assert resp.status_code == 200
+    assert resp.text.strip() == "OK"
+
+    resp = requests.post(f"{BASE_URL}/run-task", json={"command": "echo hello"})
+    assert resp.status_code == 200
+    assert resp.json()["output"].strip() == "hello"
+
+
+def test_ensure_agent_alive_restart():
+    ensure_agent_alive()
+    with open("flask.pid") as f:
+        pid = int(f.read().strip())
+
+    stop_agent()
+    with pytest.raises(Exception):
+        requests.get(f"{BASE_URL}/status", timeout=1)
+
+    restarted = ensure_agent_alive()
+    assert restarted
+
+    with open("flask.pid") as f:
+        new_pid = int(f.read().strip())
+    assert new_pid != pid


### PR DESCRIPTION
## Summary
- add basic Flask agent tests
- add helper script to start the Flask agent
- ignore temporary pid/log files
- add pytest to requirements and a lightweight dev requirements file
- run tests in GitHub Actions

## Testing
- `pre-commit run --files start_flask.sh .gitignore requirements.txt requirements-dev.txt .github/workflows/test.yml tests/test_agent.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862be9b28088330918d339abc3e9ad1